### PR TITLE
Give proper service API endpoint to complete the example docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,7 @@ services:
       - "8082"
     environment:      
       - name=${crawlerName}
+      - apiUrl=http://serviceapi:8081
     volumes:
       - ${pathToCrawl}:/usr/data
 


### PR DESCRIPTION
[Default URL for the crawler to communicate to the API appears to be using 8080](https://github.com/RD17/ambar/blob/master/LocalCrawler/src/config.js), but the example docker-compose file uses 8081. This just ensures that the crawler works more seamlessly for someone trying to get up and going. 