### PR TITLE
LocalCrawler/Configuration: correct api url

### DIFF
--- a/LocalCrawler/src/config.js
+++ b/LocalCrawler/src/config.js
@@ -2,7 +2,7 @@ const defaultConfig = {
 	"port": 8082,
 	"bodyLimit": "10mb",	
 	"crawlPath": "/usr/data",
-	"apiUrl": "http://serviceapi:8080",
+	"apiUrl": "http://webapi:8080",
 	"ignoreFolders": "**/test/**",
 	"ignoreExtensions": ".{exe,dll}",
 	"ignoreFileNames": "~*",	


### PR DESCRIPTION
Hello Maintainers,

I run in the issue #238. Based on the used port numbers I made the assumption that the URL http://serviceapi:8080 is wrong. I adapted the URL to http://webapi:8080 the crawler start to work.

This pull requests change only the URL of the local crawler.

Best Regards,
smstern