### PR TITLE
add brief section to readme about building docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,26 @@ You can build Docker images by yourself or buy prebuilt Docker images for **$50*
 
 If you want to see how Ambar works w/o installing it, try our [live demo](https://app.ambar.cloud/). No signup required.
 
+## Building the images yourself
+
+All of the images required to run ambar can be built by the user. In general, each image can be built by navigating into the directory of the component in question, performing any compilation steps required, then building the image like so:
+
+```
+# From project root
+$ cd FrontEnd
+$ docker build . -t <image_name>
+```
+
+The resulting image can be referred to by the name specified, and run by the containerization tooling of your choice.
+
+Note that some of the components require compilation or other build steps before the docker images can be built. For example, `FrontEnd`:
+
+```
+# Assuming a suitable version of node.js is installed (docker uses 8.10)
+$ npm install
+$ npm run compile
+```
+
 ## FAQ
 ### Is it open-source?
 Yes, it's fully open-source.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,18 @@ $ docker build . -t <image_name>
 
 The resulting image can be referred to by the name specified, and run by the containerization tooling of your choice.
 
-Note that some of the components require compilation or other build steps before the docker images can be built. For example, `FrontEnd`:
+In order to use a local Dockerfile with `docker-compose`, simply change the `image` option to `build`, setting the value to the relative path of the directory containing the dockerfile. Then run `docker-compose build` to build the relevant images. For example:
+
+```
+# docker-compose.yml from project root, referencing local dockerfiles
+pipeline0:
+  build: ./Pipeline/
+image: chazu/ambar-pipeline
+  localcrawler:
+    image: ./LocalCrawler/
+```
+
+Note that some of the components require compilation or other build steps be performed _on the host_ before the docker images can be built. For example, `FrontEnd`:
 
 ```
 # Assuming a suitable version of node.js is installed (docker uses 8.10)


### PR DESCRIPTION
Per @sochix suggestion in #247 - This PR provides a short section in the README on how to build the docker images. It doesn't lay out the specifics for each image, but I can add more detail if you like.

Let me know what other changes you prefer before merge, or feel free to tweak the doc.

Thanks!