### PR TITLE
Compile FrontEnd as part of building the Docker image

### DIFF
--- a/FrontEnd/Dockerfile
+++ b/FrontEnd/Dockerfile
@@ -1,3 +1,9 @@
+FROM node:8.10 as builder
+
+COPY . .
+RUN yarn install
+RUN yarn run compile
+
 FROM nginx:latest
 
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y curl
@@ -7,7 +13,7 @@ ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 COPY default /etc/nginx/conf.d/default.conf
-COPY dist /usr/share/nginx/html
+COPY --from=builder dist /usr/share/nginx/html
 
 CMD echo $api > /usr/share/nginx/html/apiUrl.txt && nginx -g "daemon off;"
 

--- a/README.md
+++ b/README.md
@@ -84,14 +84,6 @@ image: chazu/ambar-pipeline
     image: ./LocalCrawler/
 ```
 
-Note that some of the components require compilation or other build steps be performed _on the host_ before the docker images can be built. For example, `FrontEnd`:
-
-```
-# Assuming a suitable version of node.js is installed (docker uses 8.10)
-$ npm install
-$ npm run compile
-```
-
 ## FAQ
 ### Is it open-source?
 Yes, it's fully open-source.


### PR DESCRIPTION
Previously, the builder must compile the FrontEnd locally before building the Docker image.

This change moves to a multi-stage Docker build for the FrontEnd: The first stage compiles the FrontEnd code, the second stage packages the build code into the existing nginx-based image.

Also removes relevant documentation for building locally from the Readme.

I know #256 #247 were already marked as "fixed", but I think this approach provides a more consistent approach with building the other application container images.

Now simply build the container image with `cd FrontEnd && docker build .`